### PR TITLE
fix: [DPE-691] Fix Homebrew build paths for M1 Macs

### DIFF
--- a/ext/Rakefile
+++ b/ext/Rakefile
@@ -4,9 +4,15 @@ require "fileutils"
 task :default => :clean do
   mac_os = (/darwin/ =~ RUBY_PLATFORM) != nil
   if mac_os
-    ENV["CPPFLAGS"] = "-I/usr/local/opt/openssl/include"
-    ENV["LDFLAGS"] = "-L/usr/local/opt/openssl/lib"
-    lib_path = File.join('/','usr','local','opt','librdkafka','lib','librdkafka.1.dylib')
+    if `uname -m`.strip == 'x64_64'
+      ENV["CPPFLAGS"] = "-I/usr/local/opt/openssl/include"
+      ENV["LDFLAGS"] = "-L/usr/local/opt/openssl/lib"
+      lib_path = File.join('/','usr','local','opt','librdkafka','lib','librdkafka.1.dylib')
+    else
+      ENV["CPPFLAGS"] = "-I/opt/homebrew/opt/openssl@1.1/include"
+      ENV["LDFLAGS"] = "-L/opt/homebrew/opt/openssl@1.1/lib"
+      lib_path = File.join('/','opt','homebrew','opt','librdkafka','lib','librdkafka.1.dylib')
+    end
     FileUtils.cp(lib_path, File.join(File.dirname(__FILE__), "librdkafka.dylib"))
   else
     lib_path = File.join('/','usr','lib','librdkafka.so.1')


### PR DESCRIPTION
The Homebrew path changed from `/usr/local/opt` to `/opt/homebrew/opt` on M1 Macs